### PR TITLE
Use underscore's clone function, and properly handle xml responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ FlickrRequest.prototype.handleResponseStream = function(response) {
 FlickrRequest.prototype.processResponse = function(response_body) {
   var self = this;
   if (response_body.match(/^\s*<\?xml/)) {
-    xml2js.parseString(response_body, function(err, result) {
+    xml2js.parseString(response_body, {'explicitArray': false}, function(err, result) {
       result = !err && _.omit(_.extend(result.rsp, result.rsp.$), '$');
       handleRes(err, result);
     });

--- a/index.js
+++ b/index.js
@@ -94,10 +94,6 @@ FlickrRequest.prototype.processResponse = function(response_body) {
       result = !err && _.omit(_.extend(result.rsp, result.rsp.$), '$');
       handleRes(err, result);
     });
-    //var upload_match = response_body.match(/<photoid>(\d+)<\/photoid>/);
-    //if (upload_match) {
-    //  response_body = JSON.stringify({photoid: upload_match[1], stat: 'ok'});
-    //}
   } else if (response_body) {
     // Bizarrely Flickr seems to send back invalid JSON (it escapes single quotes in certain circumstances?!?!!?)
     // We fix that here. <- Sujal

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var url = require('url');
 var querystring = require('querystring');
 var OAuth = require('oauth').OAuth;
 var FormData = require('form-data');
+var _ = require('underscore');
 
 function Flickr(consumer_key, consumer_secret, oauth_token, oauth_token_secret, base_url) {
   this.consumer_key = consumer_key;
@@ -27,7 +28,7 @@ function FlickrRequest(client, method, params, signed_in, callback) {
 }
 FlickrRequest.prototype.queryString = function() {
   // easy Object.clone hack
-  var params = JSON.parse(JSON.stringify(this.params));
+  var params = _.clone(this.params);
   params.format = 'json';
   params.nojsoncallback = '1';
   if (this.signed_in) params.api_key = this.client.consumer_key;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "repository": "git://github.com/chbrown/flickr-with-uploads.git",
   "dependencies": {
     "oauth": "git://github.com/chbrown/node-oauth.git",
-    "form-data": "*"
+    "form-data": "*",
+    "underscore": "*"
   },
   "main": "index"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "oauth": "git://github.com/chbrown/node-oauth.git",
     "form-data": "*",
-    "underscore": "*"
+    "underscore": "*",
+    "xml2js": "0.2.x"
   },
   "main": "index"
 }


### PR DESCRIPTION
`JSON.stringify` fails you give it an object that has circular references (which can happen with the 'photo' param).
