### PR TITLE
Fix for Content-Length 411 Error from Flickr when uploading file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "flickr-with-uploads",
   "description": "Simple Flickr API for Node.js using OAuth 1.0a, supporting uploads.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "authors": [
     "Christopher Brown <audiere@gmail.com>",
-    "Sujal Shah <codesujal@gmail.com>"
+    "Sujal Shah <codesujal@gmail.com>",
+	"Jaroslaw Pendowski <jarek@pendowski.com"
   ],
   "keywords": ["flickr", "uploads", "api", "oauth"],
   "repository": "git://github.com/chbrown/flickr-with-uploads.git",


### PR DESCRIPTION
Had some problems with uploading to flickr lately - API.
Always got 411 Errors because lack of Content-Length in headers.
