### PR TITLE
There might have been a change to Flickr API

### DIFF
--- a/orm/photoset.js
+++ b/orm/photoset.js
@@ -114,7 +114,7 @@ Photoset.prototype.ready = function(callback) {
         }, function(err, res) {
           if (err) return callback(err);
 
-          self.id = res.photoset.id;
+          self.id = res.photoset[0].$.id;
           self.emit('ready');
         });
       }


### PR DESCRIPTION
Uploading photos work, but they are not added to a photo set (only the "pimary" is), which forces the sync-command into an infinite error-loop.
This is because the ID of the created photoset is not assigned properly.
This pull request fixes that!
